### PR TITLE
fix: android bottom covered

### DIFF
--- a/src/main/Popup.js
+++ b/src/main/Popup.js
@@ -7,7 +7,7 @@ class Popup extends Component {
   constructor(props) {
     super(props);
 
-    this.height = Platform.OS === 'android' ? Dimensions.get('screen').height - StatusBar.currentHeight : Dimensions.get('window').height;
+    this.height = Dimensions.get('window').height;
     this.width = Platform.OS === 'android' ? Dimensions.get('screen').width : Dimensions.get('window').width;
 
     this.defaultState = {


### PR DESCRIPTION
![Snip20221208_1](https://user-images.githubusercontent.com/854370/206496645-127b20ef-ce34-47ff-a425-394230de2ff1.png)
On some android phones, the bottom will be covered by the popup element