### PR TITLE
adds missing type definitions for config and other methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,7 +53,7 @@ declare module "react-native-popup-confirm-toast" {
   }
 
   export interface SPSheet {
-    show: (props: Config) => void
+    show: (props: SheetConfig) => void
     setHeight: (height: number, onOpenComplete: () => void) => void
     hide: () => void
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -61,4 +61,5 @@ declare module "react-native-popup-confirm-toast" {
   export const Toast: Toast
   export const Popup: Popup
   export const SPSheet: SPSheet
+  export const Root: FC
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module "react-native-popup-confirm-toast" {
   import { FC } from "react"
   import { StyleProp, TextStyle, ViewStyle } from "react-native"
-  import { IconProps } from "react-native-vector-icons/Icon"
+  
   export interface Config {
     title?: string
     text?: string
@@ -10,7 +10,7 @@ declare module "react-native-popup-confirm-toast" {
     backgroundColor?: string
     timeColor?: string
     position?: "top" | "bottom"
-    icon?: FC<IconProps>
+    icon?: FC
     timing?: number
     statusBarType?: "default" | "dark-content" | "light-content"
     statusBarTranslucent?: boolean

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,16 +1,64 @@
-import Root from './src/main/Root';
-import Popup from './src/main/Popup';
-import Toast from './src/main/Toast';
-import SPSheet from './src/main/SPSheet';
-import {getStatusBarHeight} from './src/main/Helper';
+declare module "react-native-popup-confirm-toast" {
+  import { FC } from "react"
+  import { StyleProp, TextStyle, ViewStyle } from "react-native"
+  import { IconProps } from "react-native-vector-icons/Icon"
+  export interface Config {
+    title?: string
+    text?: string
+    titleTextStyle?: StyleProp<TextStyle>
+    descTextStyle?: StyleProp<TextStyle>
+    backgroundColor?: string
+    timeColor?: string
+    position?: "top" | "bottom"
+    icon?: FC<IconProps>
+    timing?: number
+    statusBarType?: "default" | "dark-content" | "light-content"
+    statusBarTranslucent?: boolean
+    statusBarHidden?: boolean
+    statusBarAndroidHidden?: boolean
+    statusBarAppleHidden?: boolean
+    hiddenDuration?: number
+    startDuration?: number
+    onOpen?: () => void
+    onOpenComplete?: () => void
+    onClose?: () => void
+    onCloseComplete?: () => void
+  }
 
-declare module 'react-native-popup-confirm-toast' {
-    // @ts-ignore
-    export {
-        Root,
-        Popup,
-        SPSheet,
-        Toast,
-        getStatusBarHeight
-    }
+  export interface SheetConfig {
+    background?: string
+    height?: number
+    duration?: number
+    closeDuration?: number
+    closeOnDragDown?: boolean
+    closeOnPressMask?: boolean
+    closeOnPressBack?: boolean
+    dragTopOnly?: boolean
+    component?: FC
+    onOpen?: () => void
+    onOpenComplete?: () => void
+    onClose?: () => void
+    onCloseComplete?: () => void
+    customStyles?: StyleProp<ViewStyle>
+    timing?: number
+    keyboardHeightAdjustment?: boolean
+  }
+  export interface Toast {
+    show: (props: Config) => void
+    hide: () => void
+  }
+  export interface Popup {
+    show: (props: Config) => void
+    hide: () => void
+  }
+
+  export interface SPSheet {
+    show: (props: Config) => void
+    setHeight: (height: number, onOpenComplete: () => void) => void
+    hide: () => void
+  }
+
+  export const Toast: Toast
+  export const Popup: Popup
+  export const SPSheet: SPSheet
 }


### PR DESCRIPTION
I created this type definition for my own project (with the help of copilot) and figured I would try to get it pulled in or at least posted here for others to copy into their project.

If you are looking to get your own project working with these type definitions in the mean time, just create a file wherever your other type files are called `react-native-popup-confirm-toast.d.ts` and paste the code in the PR. you shoult be all good after that.

I didn't go so far as to look into all the code to make sure functions don't return an event for instance so the functions may not be 100% accurate in that regard but I doubt many will need anything in such an event anyway since they're mostly just used as callbacks it seems.